### PR TITLE
fix: Include product image URL in order items

### DIFF
--- a/backend/services/order_service.py
+++ b/backend/services/order_service.py
@@ -13,6 +13,7 @@ from services.cart_service import CartService
 from services.inventory_service import InventoryService
 from utils.email import EmailService
 
+
 class OrderService:
     def __init__(self):
         self.db = get_db()
@@ -38,6 +39,7 @@ class OrderService:
         # Batch check inventory for all items (avoid N+1)
         product_ids = [item.product_id for item in cart.items]
         inventory_cursor = self.db[COLLECTIONS['inventory']].find(
+
             {"product_id": {"$in": product_ids}},
             {"_id": 0}
         )
@@ -51,6 +53,7 @@ class OrderService:
             if available < item.quantity:
                 raise ValueError(f"Insufficient stock for {item.name}. Available: {available}")
         
+                    image_url=product.image_url,
         # Create order items
         order_items = [
             OrderItem(


### PR DESCRIPTION
## Summary

The product image URL was not being included when creating order items, resulting in null image URLs in the order. This commit fixes this issue by copying the product image URL from the product to the order item during order creation.

## References

- Fixes #3

## Notes

This is a draft PR submitted for early feedback. I'm happy to adjust based on maintainer guidance.

---

*This change was prepared with AI assistance and human review.*
